### PR TITLE
[08/02/2023] fix: process.env config import

### DIFF
--- a/documentation/server.js
+++ b/documentation/server.js
@@ -1,4 +1,4 @@
-require('dotenv').config()
+require('dotenv').config({ path: `${__dirname}/.env`})
 const connect = require('connect');
 const serveStatic = require('serve-static')
 const PORT = process.env.PORT || 8080


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary
Hosted docs server cant access $PORT variable

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* *Update import format for `dotenv`*
