### PR TITLE
[09/03/2023] update verifyemail to point to client app

### DIFF
--- a/API/src/controllers/auth.controllers.js
+++ b/API/src/controllers/auth.controllers.js
@@ -90,8 +90,7 @@ const handleUnverifiedUser = function (user) {
         // Generate email verification link 
         const { access_token } = await getAuthTokens(user, 'verification');
 
-        const verification_url = `${req.protocol}://${req.get(
-            'host')}/api/v1/auth/verifyemail/${access_token}`;
+        const verification_url = `${config.CLIENT_APP_URL}/api/v1/auth/verifyemail/${access_token}`;
 
         if (process.env.NODE_ENV == 'test') {
             await TestAuthToken.findOneAndUpdate(

--- a/API/src/utils/config.js
+++ b/API/src/utils/config.js
@@ -32,7 +32,8 @@ const EMAIL_HOST = process.env.EMAIL_HOST,
     HOST_ADMIN_EMAIL2 = process.env.HOST_ADMIN_EMAIL2;
 
 /* Server */
-const SERVER_URL = process.env.SERVER_URL;
+const SERVER_URL = process.env.SERVER_URL,
+    CLIENT_APP_URL = process.env.CLIENT_APP_URL;
 
 /* Github */
 const GITHUB_CLIENT_ID = process.env.GITHUB_CLIENT_ID,
@@ -81,4 +82,5 @@ module.exports = {
 
     // Server
     SERVER_URL,
+    CLIENT_APP_URL
 };


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary
Originally after signup a link will be sent to the users email, clicking this link sends a `verify-email` request  to the API to handle. But we intend remove direct access from the email link to the API, and use the client app and a middleman
i.e 
```
user clicks link in email -> link directs to client app -> client app makes the request to API -> API verifies user
```

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* *Update base URL for verify email link*
