### PR TITLE
[26/03/2023] fix: `GET /courses` and duplicate signup 

### DIFF
--- a/API/src/controllers/auth.controllers.js
+++ b/API/src/controllers/auth.controllers.js
@@ -97,7 +97,9 @@ const signToken = (id, role, jwtSecret = null, expiry = null) => {
  * @throws {Error} If error occurs
  */
 const returnAuthTokens = async (user, statusCode, res) => {
-    const { access_token, refresh_token } = await getAuthTokens(user);
+    console.log(user)
+    if (!user.status) user = await User.findById(user._id).populate('status');
+    const { access_token, refresh_token } = await getAuthTokens(user.toObject());
 
     // Remove sensitive data from user object
     user.password = undefined;
@@ -106,6 +108,8 @@ const returnAuthTokens = async (user, statusCode, res) => {
     user.passwordResetToken = undefined;
     user.isVerified = undefined;
     user.auth_code = undefined;
+
+    console.log(access_token)
 
     res.status(statusCode).json({
         success: true,
@@ -926,7 +930,7 @@ exports.googleSignin = async (req, res, next) => {
         audience: config.OAUTH_CLIENT_ID,
     }),
         payload = ticket.getPayload(),
-        existing_user = await User.findOne({ email: payload.email });
+        existing_user = await User.findOne({ email: payload.email }).populate('status')
 
     // Create new user in db
     const random_str = UUID(); // Random unique str as password, won't be needed for authentication
@@ -941,9 +945,26 @@ exports.googleSignin = async (req, res, next) => {
             googleId: payload.sub,
         };
 
-        const new_user = await User.create(user_data);
-        returnAuthTokens(new_user, 200, res);
+        const session = await mongoose.startSession();
+        let new_user;
+        await session.withTransaction(async () => {
+            await User.create(
+                [{ ...user_data }], { session, context: 'query' }
+            ).then((user) => { new_user = user[0] });
+
+            await Password.create([{ user: new_user._id, password: user_data.password }], { session, context: 'query' });
+            await Status.create([{ user: new_user._id }], { session, context: 'query' })
+            await AuthCode.create([{ user: new_user._id }], { session, context: 'query' })
+
+            await session.commitTransaction()
+            session.endSession()
+        })
+
+        await returnAuthTokens(new_user, 200, res);
+        return
     }
+
+    console.log(existing_user.toObject())
 
     await returnAuthTokens(existing_user, 200, res)
 };

--- a/API/src/controllers/auth.controllers.js
+++ b/API/src/controllers/auth.controllers.js
@@ -167,9 +167,8 @@ const handleUnverifiedUser = function (user) {
  */
 const handleExistingUser = function (user) {
     return async function (req, res, next) {
-        const existing_user = user.toJSON({ virtuals: true });
+        const existing_user = user.toObject();
 
-        //console.log(existing_user);
         // If user is not verified - send verification email
         if (!existing_user.status.isVerified) {
             await handleUnverifiedUser(existing_user)(req);
@@ -246,7 +245,6 @@ exports.signup = async (req, res, next) => {
 
     // Check if user already exists
     const existing_user = await User.findOne({ email }).populate('status')
-    // //console.log(existing_user)
     if (existing_user) return handleExistingUser(existing_user)(req, res, next);
 
     let new_user;

--- a/API/src/middlewares/auth.js
+++ b/API/src/middlewares/auth.js
@@ -79,7 +79,6 @@ const config = require('../utils/config');
  */
 const basicAuth = function (token_type = null) {
     return async (req, res, next) => {
-        console.log(token_type)
         // Check if the request has a valid authorization header
         const authHeader = req.headers.authorization;
         if (!authHeader || !authHeader.startsWith('Bearer ')) {

--- a/API/src/middlewares/auth.js
+++ b/API/src/middlewares/auth.js
@@ -86,10 +86,11 @@ const basicAuth = function (token_type = null) {
             return next(new UnauthenticatedError('Invalid authorization header'));
         }
 
+        if (token_type == 'optional') return next();
+
         // Use the default access token secret if token_type is not specified or is optional
         // Otherwise use the secret for the specified token type
-        token_type =
-          !token_type | (token_type == "optional") ? "access" : token_type;
+        token_type = !token_type ? "access" : token_type;
 
         let { secret } = getRequiredConfigVars(token_type)
 
@@ -115,6 +116,7 @@ const basicAuth = function (token_type = null) {
                 .send({ message: 'success', access_token: new_access_token });
         }
 
+        console.log(req.user)
         if (!req.user.status.isActive && !token_type) {
             return next(
                 new UnauthenticatedError(

--- a/API/src/middlewares/auth.js
+++ b/API/src/middlewares/auth.js
@@ -26,7 +26,7 @@ const config = require('../utils/config');
 /**
  * Middleware to check if the request has a valid authorization header
  * and if the token is valid.
-*
+ * 
  * @description This middleware checks if the incoming request 
  * has a valid authorization header with a JWT token,
  * and verifies the token to ensure that it's valid. 
@@ -79,6 +79,7 @@ const config = require('../utils/config');
  */
 const basicAuth = function (token_type = null) {
     return async (req, res, next) => {
+        console.log(token_type)
         // Check if the request has a valid authorization header
         const authHeader = req.headers.authorization;
         if (!authHeader || !authHeader.startsWith('Bearer ')) {
@@ -86,8 +87,12 @@ const basicAuth = function (token_type = null) {
             return next(new UnauthenticatedError('Invalid authorization header'));
         }
 
-        token_type = token_type == 'optional' ? 'access' : token_type
-        let secret = getRequiredConfigVars(token_type).secret
+        // Use the default access token secret if token_type is not specified or is optional
+        // Otherwise use the secret for the specified token type
+        token_type =
+          !token_type | (token_type == "optional") ? "access" : token_type;
+
+        let { secret } = getRequiredConfigVars(token_type)
 
         // Verify the token
         const jwtToken = authHeader.split(' ')[1]; //console.log(jwtToken)

--- a/API/src/routes/course.routes.js
+++ b/API/src/routes/course.routes.js
@@ -13,7 +13,7 @@ const permit = require("../middlewares/permission_handler")
 const { basicAuth } = require("../middlewares/auth")
 
 
-router.get("/:id", basicAuth('optional'), permit("Admin EndUser SuperAdmin"), getCourseData)
+router.get("/:id", basicAuth('optional'), getCourseData)
 
 router.use(basicAuth())
 router


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary
When making request to the `GET  /courses` route it returns an `InternalServerError` also for duplicate signup it also returned and `InternalServerError` the issues had something to do with JWT token management in the authentication middleware

### List of changes proposed in this PR (pull-request)
* *Fix `GET /courses` route*
* *Fix duplicate signup response*
* *Fix Google signin not adding status document*
