### PR TITLE
[26/03/2023] add record of percentage passed and best score

### DIFF
--- a/API/src/controllers/exercise.controllers.js
+++ b/API/src/controllers/exercise.controllers.js
@@ -385,7 +385,7 @@ exports.scoreExercise = async (req, res, next) => {
 
         // Check if submitted option is correct. If yes, increment score
         if (question.correct_option == submitted_option) score++;
-
+        
         exercise_submission.submission.push({
             question: question._id,
             submitted_option: submitted_option,
@@ -424,8 +424,8 @@ exports.scoreExercise = async (req, res, next) => {
         success: true,
         data: {
             report: {
-                ...exercise_submission.toObject(), best_score:
-                    exercise_report.best_score,
+                ...exercise_submission.toObject(), 
+                best_score: exercise_report.best_score,
                 percentage_passed: exercise_report.percentage_passed,
             },
             certificate,

--- a/API/src/controllers/exercise.controllers.js
+++ b/API/src/controllers/exercise.controllers.js
@@ -419,14 +419,17 @@ exports.scoreExercise = async (req, res, next) => {
     let certificate = course_report.isCompleted
         ? await issueCertificate(course_report._id)
         : null;
+    
+    console.log(exercise_submission)
 
     return res.status(200).send({
         success: true,
         data: {
             report: {
                 ...exercise_submission.toObject(), 
+                percentage_passed: exercise_submission.percentage_passed,
                 best_score: exercise_report.best_score,
-                percentage_passed: exercise_report.percentage_passed,
+                best_percentage_passed: exercise_report.percentage_passed,
             },
             certificate,
         },

--- a/API/src/models/course.models.js
+++ b/API/src/models/course.models.js
@@ -369,8 +369,23 @@ const exerciseSubmissionSchema = new Schema({
         })
     }],
     score: { type: Number, default: 0 },
+    percentage_passed: { type: Number, default: 0 },
     report: { type: Schema.Types.ObjectId, ref: "ExerciseReport", required: true }
 }, options)
+exerciseSubmissionSchema.pre('save', async function (next) {
+    // check if score was updated
+    if (this.isModified('score')) {
+        // get the exercise
+        const { exercise } = await this.populate({
+            path: 'exercise',
+            populate: 'questions'
+        })
+
+        this.percentage_passed = (this.score / exercise.questions.length) * 100
+    }
+
+    next()
+})
 
 const exerciseReportSchema = new Schema({
     exercise: { type: Schema.Types.ObjectId, ref: 'ExerciseReport', required: true },


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary
Initially when a user submits an exercise for grading, the response only shows the current score, but in this PR i included the percentage_passed, the best_score the user has had, and the best_percentage, this can be used to check if a user has ever passed the benchmark for finishing the course. It'll be needed when checking the criteria for getting a certificate

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* *Add `percentage_passed` `best_score` & `best_percentage_passed` to scoreExercise respone*
