### PR TITLE
[04/04/2023] fix: course progress calculation

### DIFF
--- a/API/src/controllers/exercise.controllers.js
+++ b/API/src/controllers/exercise.controllers.js
@@ -109,17 +109,16 @@ exports.createExercise = async (req, res, next) => {
 exports.getExercises = async (req, res, next) => {
     let exercises;
     // If any specific query was added 
-    if (req.body) {
+    if (req.body && Object.keys(req.body).length > 0) {
+        console.log('req.body', req.body)
         exercises = await Exercise.find(req.body)
     }
 
     // Sort the exercises according to how they where added
-    exercises = exercises ? await Exercise.find().populate('questions') : exercises
+    exercises = !exercises ? await Exercise.find().populate('questions') : exercises
 
     // Get only the available courses
-    const available_exercises = exercises.filter((exercise) => {
-        if (exercise.isAvailable) return exercise.toJSON();
-    })
+    const available_exercises = exercises.filter((exercise) => exercise.toJSON() )
 
     return res.status(200).json({
         success: true,
@@ -418,7 +417,7 @@ exports.scoreExercise = async (req, res, next) => {
     let certificate = course_report.isCompleted
         ? await issueCertificate(course_report._id)
         : null;
-    
+
     return res.status(200).send({
         success: true,
         data: {

--- a/API/src/models/course.models.js
+++ b/API/src/models/course.models.js
@@ -467,16 +467,25 @@ courseReportSchema.virtual('attempted_exercises', {
 })
 
 courseReportSchema.methods.updateBestScore = async function () {
-    const doc = (await this.populate("attempted_exercises")).toObject();
+    const doc = (await this.populate([
+        {
+            path: 'attempted_exercises',
+        },
+        {
+            path: 'course',
+            populate: 'exercises'
+        }
+    ])).toObject();
 
-    const exercises = doc.attempted_exercises;
+    const attempted_exercises = doc.attempted_exercises;
+    const required_exercises = doc.course.exercises;
     let total_scores = 0
-    for (let i = 0; i < exercises.length; i++) {
-        total_scores += exercises[i].percentage_passed
+    for (let i = 0; i < attempted_exercises.length; i++) {
+        total_scores += attempted_exercises[i].percentage_passed
     }
 
     // Calculate the average percentage passed 
-    this.percentage_passed = total_scores / exercises.length
+    this.percentage_passed = total_scores / required_exercises.length
 
     // Update the isCompleted field if the percentage passed is greater than or equal to 80
     this.isCompleted = this.percentage_passed >= 80 ? true : false;

--- a/API/src/routes/exercise.routes.js
+++ b/API/src/routes/exercise.routes.js
@@ -12,8 +12,8 @@ const {
 router.use(basicAuth())
 
 router
-    .get("/:id", getExerciseData)
     .get("/", getExercises)
+    .get("/:id", getExerciseData)
     .post("/new", permit('Admin SuperAdmin'), createExercise)
     .patch("/update/:id", permit('Admin SuperAdmin'), updateExercise)
     .delete("/delete/:id", permit('Admin SuperAdmin'), deleteExercise)


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary
The course progress calculation was returning a wrong calculation, if a user only attempts 3 out of 7 exercises in a course, and  he/she gets 100% score, the course progress counts at 100% which is the average of the 3 attempted exercises, this is wrong.
The correct course progress should be calculated by considering all the exercises in the course both the attempted once and unattempted exercises

### List of changes proposed in this PR (pull-request)
* *Fix course progress calculation*

